### PR TITLE
Certificate parsing fix

### DIFF
--- a/acm.go
+++ b/acm.go
@@ -53,7 +53,7 @@ func separateCerts(name string, ca, crt, key []byte) *Certificate {
 	b := "-----BEGIN CERTIFICATE-----\n"
 	str := strings.Split(string(crt), b)
 	nc := b + str[1]
-	ch := strings.Join(str[:len(str)-1], b)
+	ch := b + strings.Join(str[2:len(str)], b)
 	cert := &Certificate{
 		SecretName:  name,
 		Chain:       []byte(ch),


### PR DESCRIPTION
We have found a bug with certificate parsing for Let's Encrypt certificates. The certificate for the domain is parsed in an incorrect way, and we do not obtain the chain part of the imported certificate in ACM.

First part is the domain certificate, rest is a chain.

Please review & merge this small fix. Thanks!