### PR TITLE
Bump alpine version to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go mod download && go mod verify
 
 RUN CGO_ENABLED=0 go build -o /app/cert-manager-sync cmd/cert-manager-sync/*.go
 
-FROM alpine:3.6 as alpine
+FROM alpine:3.21 as alpine
 
 RUN apk add -U --no-cache ca-certificates
 


### PR DESCRIPTION
In order to update trusted CA certificates the alpine version need to get bumped. The CA for our vault certificate isn't trusted in alpine 3.6 but is in more recent versions.