### PR TITLE
Update Go base image version to 1.25.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7 as builder
+FROM golang:1.25.8 as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Several vulnerabilities were fixed in version 1.25.8

* https://go.dev/issue/77952.
* https://go.dev/issue/77953
* https://go.dev/issue/77954
* https://go.dev/issue/77578.
* https://go.dev/issue/77827

See also: https://seclists.org/oss-sec/2026/q1/262