### PR TITLE
ci: Add PR pipeline with Trivy, gosec, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - run: go test ./...
+
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          exit-code: 1
+
+  gosec:
+    name: Gosec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - run: go install github.com/securego/gosec/v2/cmd/gosec@223e19b8856e00f02cc67804499a83f77e208f3c # v2.25.0
+      - run: gosec -severity medium -confidence medium -exclude=G115,G703,G117 ./...


### PR DESCRIPTION
## Summary

Add a GitHub Actions CI pipeline that runs on pull requests to `main`.

## Jobs

| Job | Tool | Description |
|---|---|---|
| Test | `go test` | Run all Go tests |
| Trivy | `aquasecurity/trivy-action` | Filesystem scan, fails on CRITICAL/HIGH vulnerabilities |
| Gosec | `securego/gosec` | Go static security analysis, fails on MEDIUM+ severity |

All three jobs run in parallel.

## Pinned SHAs

All action references use commit SHAs instead of tags:
- `actions/checkout` @ `de0fac2e` (v6.0.2)
- `actions/setup-go` @ `4a360112` (v6.4.0)
- `aquasecurity/trivy-action` @ `57a97c7e` (v0.35.0)
- `securego/gosec` @ `223e19b8` (v2.25.0)